### PR TITLE
Modifications to DigitBuilder to run new geometry; typos in LoadWCSim

### DIFF
--- a/UserTools/DigitBuilder/DigitBuilder.cpp
+++ b/UserTools/DigitBuilder/DigitBuilder.cpp
@@ -212,7 +212,7 @@ bool DigitBuilder::BuildPMTRecoDigit() {
 			  }
       }
 		} // end loop over MCHits
-  } else {
+	} else {
 		cout<<"No MCHits"<<endl;
 		return false;
 	}

--- a/UserTools/DigitBuilder/DigitBuilder.cpp
+++ b/UserTools/DigitBuilder/DigitBuilder.cpp
@@ -187,9 +187,9 @@ bool DigitBuilder::BuildPMTRecoDigit() {
           std::sort(hitTimes.begin(), hitTimes.end());
           size_t timesize = hitTimes.size();
           if (timesize % 2 == 0){
-            calT = (hitTimes[timesize/2 - 1] + hitTimes[timesize/2])/2;
+            calT = (hitTimes.at(timesize/2 - 1) + hitTimes.at(timesize/2))/2;
           } else {
-            calT = hitTimes[timesize/2];
+            calT = hitTimes.at(timesize/2);
           }
           calQ = 0.;
           for(std::vector<double>::iterator it = hitCharges.begin(); it != hitCharges.end(); ++it){

--- a/UserTools/DigitBuilder/DigitBuilder.cpp
+++ b/UserTools/DigitBuilder/DigitBuilder.cpp
@@ -23,11 +23,14 @@ bool DigitBuilder::Initialise(std::string configfile, DataModel &data){
   //m_variables.Print();
 
   m_data= &data; //assigning transient data pointer
-  /////////////////////////////////////////////////////////////////
-  fPhotodetectorConfiguration = "All";
   
+  ///////////////////// Defaults for Config ///////////////
+  fPhotodetectorConfiguration = "All";
+  fParametricModel = 0;
+
   /// Get the Tool configuration variables
 	m_variables.Get("verbosity",verbosity);
+	m_variables.Get("ParametricModel", fParametricModel);
 	m_variables.Get("PhotoDetectorConfiguration", fPhotodetectorConfiguration);
 	
 	/// Construct the other objects we'll be setting at event level,
@@ -41,6 +44,7 @@ bool DigitBuilder::Initialise(std::string configfile, DataModel &data){
   // I would recommend moving away from the use of WCSim IDs if possible as they are liable to change
   // but for tools that need them, in the LoadWCSim tool I put a map of WCSim TubeId to channelkey
   m_data->CStore.Get("detectorkey_to_lappdid",detectorkey_to_lappdid);
+  m_data->CStore.Get("channelkey_to_pmtid",channelkey_to_pmtid);
   
   return true;
 }
@@ -154,7 +158,8 @@ bool DigitBuilder::BuildPMTRecoDigit() {
 		for(std::pair<unsigned long,std::vector<Hit>>&& apair : *fMCHits){
 			unsigned long chankey = apair.first;
 			// the channel key is a unique identifier of this signal input channel
-			det = fGeometry.ChannelToDetector(chankey);
+			det = fGeometry->ChannelToDetector(chankey);
+      int PMTId = channelkey_to_pmtid.at(chankey);  //PMTID In WCSim
 			if(det==nullptr){
 				Log("DigitBuilder Tool: Detector not found! ",v_message,verbosity);
 				continue;
@@ -170,20 +175,44 @@ bool DigitBuilder::BuildPMTRecoDigit() {
 	
 			if(det->GetDetectorElement()=="Tank"){
 				std::vector<Hit>& hits = apair.second;
-			  for(Hit& ahit : hits){
-			  	//ahit.Print();
-					//if(v_message<verbosity) ahit.Print(); // << VERY verbose
-					// get calibrated PMT time (Use the MC time for now)
-					calT = ahit.GetTime()*1.0; // remove 950 ns offs
-					calQ = ahit.GetCharge();
-					digitType = RecoDigit::PMT8inch;
-					RecoDigit recoDigit(region, pos_reco, calT, calQ, digitType, (int)chankey);
-				  //recoDigit.Print();
+        if(fParametricModel){
+          //We'll get all hit info and then define a time/charge for each digit
+          std::vector<double> hitTimes;
+          std::vector<double> hitCharges;
+          for(Hit& ahit : hits){
+					  hitTimes.push_back(ahit.GetTime()*1.0); 
+            hitCharges.push_back(ahit.GetCharge());
+          }
+          // Do median and sum
+          std::sort(hitTimes.begin(), hitTimes.end());
+          size_t timesize = hitTimes.size();
+          if (timesize % 2 == 0){
+            calT = (hitTimes[timesize/2 - 1] + hitTimes[timesize/2])/2;
+          } else {
+            calT = hitTimes[timesize/2];
+          }
+          calQ = 0.;
+          for(std::vector<double>::iterator it = hitCharges.begin(); it != hitCharges.end(); ++it){
+            calQ += *it;
+          }
+				  digitType = RecoDigit::PMT8inch;
+				  RecoDigit recoDigit(region, pos_reco, calT, calQ, digitType, PMTId);
 				  fDigitList->push_back(recoDigit); 
-        }
-			}
+        } else {
+			    for(Hit& ahit : hits){
+				  	//if(v_message<verbosity) ahit.Print(); // << VERY verbose
+				  	// get calibrated PMT time (Use the MC time for now)
+				  	calT = ahit.GetTime()*1.0; 
+            calQ = ahit.GetCharge();
+				  	digitType = RecoDigit::PMT8inch;
+				  	RecoDigit recoDigit(region, pos_reco, calT, calQ, digitType, PMTId);
+				    //recoDigit.Print();
+				    fDigitList->push_back(recoDigit); 
+          }
+			  }
+      }
 		} // end loop over MCHits
-	} else {
+  } else {
 		cout<<"No MCHits"<<endl;
 		return false;
 	}
@@ -206,7 +235,11 @@ bool DigitBuilder::BuildLAPPDRecoDigit() {
 		// iterate over the map of sensors with a measurement
 		for(std::pair<unsigned long,std::vector<LAPPDHit>>&& apair : *fMCLAPPDHits){
 			unsigned long chankey = apair.first;
-			det = fGeometry.ChannelToDetector(chankey);
+			det = fGeometry->ChannelToDetector(chankey);
+			if(det==nullptr){
+				Log("DigitBuilder Tool: LAPPD Detector not found! ",v_message,verbosity);
+				continue;
+			}
 			int detkey = det->GetDetectorID();
 			int LAPPDId = detectorkey_to_lappdid.at(detkey); // WCSim's LAPPDID
 			// XXX ^ this is here for demonstration, since it will tie up with
@@ -214,7 +247,7 @@ bool DigitBuilder::BuildLAPPDRecoDigit() {
 			// but I recommend transitioning to a more robust method
 			//if(LAPPDId != 266 && LAPPDId != 271 && LAPPDId != 236 && LAPPDId != 231 && LAPPDId != 206) continue;
 			//if(LAPPDId != 90 && LAPPDId != 83 && LAPPDId != 56 && LAPPDId != 59 && LAPPDId != 22) continue;
-                        if(det->GetDetectorElement()=="LAPPD"){ // redundant, MCLAPPDHits are LAPPD hitss
+      if(det->GetDetectorElement()=="LAPPD"){ // redundant, MCLAPPDHits are LAPPD hitss
 				std::vector<LAPPDHit>& hits = apair.second;
 				for(LAPPDHit& ahit : hits){
 					//if(v_message<verbosity) ahit.Print(); // << VERY verbose
@@ -232,7 +265,7 @@ bool DigitBuilder::BuildLAPPDRecoDigit() {
 					// here I just set the charge to 1. We should come back to this later. (Jingbo Wang)
 					calQ = 1.;
 					digitType = RecoDigit::lappd_v0;
-					RecoDigit recoDigit(region, pos_reco, calT, calQ, digitType,(int)chankey);
+					RecoDigit recoDigit(region, pos_reco, calT, calQ, digitType,LAPPDId);
 					//if(v_message<verbosity) recoDigit.Print();
 				  fDigitList->push_back(recoDigit);
 				}

--- a/UserTools/DigitBuilder/DigitBuilder.cpp
+++ b/UserTools/DigitBuilder/DigitBuilder.cpp
@@ -159,7 +159,7 @@ bool DigitBuilder::BuildPMTRecoDigit() {
 			unsigned long chankey = apair.first;
 			// the channel key is a unique identifier of this signal input channel
 			det = fGeometry->ChannelToDetector(chankey);
-      int PMTId = channelkey_to_pmtid.at(chankey);  //PMTID In WCSim
+			int PMTId = channelkey_to_pmtid.at(chankey);  //PMTID In WCSim
 			if(det==nullptr){
 				Log("DigitBuilder Tool: Detector not found! ",v_message,verbosity);
 				continue;
@@ -247,7 +247,7 @@ bool DigitBuilder::BuildLAPPDRecoDigit() {
 			// but I recommend transitioning to a more robust method
 			//if(LAPPDId != 266 && LAPPDId != 271 && LAPPDId != 236 && LAPPDId != 231 && LAPPDId != 206) continue;
 			//if(LAPPDId != 90 && LAPPDId != 83 && LAPPDId != 56 && LAPPDId != 59 && LAPPDId != 22) continue;
-      if(det->GetDetectorElement()=="LAPPD"){ // redundant, MCLAPPDHits are LAPPD hitss
+			if(det->GetDetectorElement()=="LAPPD"){ // redundant, MCLAPPDHits are LAPPD hitss
 				std::vector<LAPPDHit>& hits = apair.second;
 				for(LAPPDHit& ahit : hits){
 					//if(v_message<verbosity) ahit.Print(); // << VERY verbose

--- a/UserTools/DigitBuilder/DigitBuilder.h
+++ b/UserTools/DigitBuilder/DigitBuilder.h
@@ -75,8 +75,9 @@ class DigitBuilder: public Tool {
 	uint64_t fMCEventNum;      ///< event number in MC file
 	std::vector<int> fLAPPDId; ///< selected LAPPDs
 	std::string fPhotodetectorConfiguration; ///< "PMTs_Only", "LAPPDs_Only", "All_Detectors"
-	
-	Geometry fGeometry;    ///< ANNIE Geometry
+	bool fParametricModel;     ///< configures if PMTs hits for each event are accumulated into one hit per PMT
+
+	Geometry* fGeometry=nullptr;    ///< ANNIE Geometry
 	std::map<unsigned long,std::vector<Hit>>* fMCHits=nullptr;             ///< PMT hits
 	std::map<unsigned long,std::vector<LAPPDHit>>* fMCLAPPDHits=nullptr;   ///< LAPPD hits
 	std::map<unsigned long,std::vector<Hit>>* fTDCData=nullptr;            ///< MRD & veto hits
@@ -115,6 +116,7 @@ class DigitBuilder: public Tool {
 	// the correct number of Channel (stripline) objects, all hits are on the 
 	// first Channel (stripline) of the Detector (tile).
 	std::map<unsigned long,int> detectorkey_to_lappdid;
+	std::map<unsigned long,int> channelkey_to_pmtid;
 	
 };
 

--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -543,7 +543,7 @@ void LoadWCSim::ConstructToolChainGeometry(){
 		// construct the channel associated with this PMT
 		unsigned long uniquechannelkey = anniegeom->ConsumeNextFreeChannelKey();
 		pmt_tubeid_to_channelkey.emplace(apmt.GetTubeNo(), uniquechannelkey);
-		channelkey_to_pmtdit.emplace(uniquechannelkey,apmt.GetTubeNo());
+		channelkey_to_pmtid.emplace(uniquechannelkey,apmt.GetTubeNo());
 		
 		// fill up ADC cards and channels monotonically, they're arbitrary for simulation
 		ADC_Chan_Num++;
@@ -695,6 +695,9 @@ void LoadWCSim::ConstructToolChainGeometry(){
 		if(verbose>4) anniegeom->PrintChannels();
 	}
 	
+  // Initialize the channel map
+  anniegeom->InitChannelMap();
+
 	// for other WCSim tools that may need the WCSim Tube IDs
 	m_data->CStore.Set("lappd_tubeid_to_detectorkey",lappd_tubeid_to_detectorkey);
 	m_data->CStore.Set("pmt_tubeid_to_channelkey",pmt_tubeid_to_channelkey);
@@ -702,7 +705,7 @@ void LoadWCSim::ConstructToolChainGeometry(){
 	m_data->CStore.Set("facc_tubeid_to_channelkey",facc_tubeid_to_channelkey);
 	// inverse
 	m_data->CStore.Set("detectorkey_to_lappdid",detectorkey_to_lappdid);
-	m_data->CStore.Set("channelkey_to_pmtdit",channelkey_to_pmtdit);
+	m_data->CStore.Set("channelkey_to_pmtid",channelkey_to_pmtid);
 	m_data->CStore.Set("channelkey_to_mrdpmtid",channelkey_to_mrdpmtid);
 	m_data->CStore.Set("channelkey_to_faccpmtid",channelkey_to_faccpmtid);
 	

--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -695,9 +695,8 @@ void LoadWCSim::ConstructToolChainGeometry(){
 		if(verbose>4) anniegeom->PrintChannels();
 	}
 	
-  // Initialize the channel map
-  anniegeom->InitChannelMap();
-
+	// Initialize the channel map
+	anniegeom->InitChannelMap();
 	// for other WCSim tools that may need the WCSim Tube IDs
 	m_data->CStore.Set("lappd_tubeid_to_detectorkey",lappd_tubeid_to_detectorkey);
 	m_data->CStore.Set("pmt_tubeid_to_channelkey",pmt_tubeid_to_channelkey);

--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -695,8 +695,6 @@ void LoadWCSim::ConstructToolChainGeometry(){
 		if(verbose>4) anniegeom->PrintChannels();
 	}
 	
-	// Initialize the channel map
-	anniegeom->InitChannelMap();
 	// for other WCSim tools that may need the WCSim Tube IDs
 	m_data->CStore.Set("lappd_tubeid_to_detectorkey",lappd_tubeid_to_detectorkey);
 	m_data->CStore.Set("pmt_tubeid_to_channelkey",pmt_tubeid_to_channelkey);

--- a/UserTools/LoadWCSim/LoadWCSim.h
+++ b/UserTools/LoadWCSim/LoadWCSim.h
@@ -87,7 +87,7 @@ class LoadWCSim: public Tool {
 	std::map<int,unsigned long> facc_tubeid_to_channelkey;
 	// inverse
 	std::map<unsigned long,int> detectorkey_to_lappdid;
-	std::map<unsigned long,int> channelkey_to_pmtdit;
+	std::map<unsigned long,int> channelkey_to_pmtid;
 	std::map<unsigned long,int> channelkey_to_mrdpmtid;
 	std::map<unsigned long,int> channelkey_to_faccpmtid;
 	

--- a/configfiles/PhaseIIRecoTruth/DigitBuilderConfig
+++ b/configfiles/PhaseIIRecoTruth/DigitBuilderConfig
@@ -1,7 +1,6 @@
 # DigitBuilder config file
 
 verbosity 3
-OutputFile ./DigitBuilder.root
 # There are three configurations: "PMT_only", "LAPPD_only", "All"
-PhotoDetectorConfiguration PMT_only 
+PhotoDetectorConfiguration All
 #LAPPDId 266 271 236 231 206

--- a/configfiles/PhaseIIRecoTruth/LoadWCSimConfig
+++ b/configfiles/PhaseIIRecoTruth/LoadWCSimConfig
@@ -2,4 +2,8 @@
 # all variables retrieved with m_variables.Get() must be defined here!
 
 verbose 1
-InputFile /AnnieShare/p2r_data/p2v6/wcsim_0.1.9.root
+HistoricTriggeroffset 0
+InputFile /AnnieShare/p2r_data/p2v6/nodigitization/wcsim_0.0.14.root
+LappdNumStrips 60        ## num channels to construct from each LAPPD
+LappdStripLength 100     ## relative x position of each LAPPD strip, for dual-sided readout [mm]
+LappdStripSeparation 10  ## stripline separation, for calculating relative y position of each LAPPD strip [mm]

--- a/configfiles/PhaseIIRecoTruth/LoadWCSimLAPPDConfig
+++ b/configfiles/PhaseIIRecoTruth/LoadWCSimLAPPDConfig
@@ -2,7 +2,7 @@
 # all variables retrieved with m_variables.Get() must be defined here!
 
 verbose 3
-InputFile /AnnieShare/p2r_data/p2v6/wcsim_lappd_0.1.9.root
+InputFile /AnnieShare/p2r_data/p2v6/nodigitization/wcsim_lappd_0.0.14.root
 # octagonal inner structure radius in m (from drawings 106.64")
 InnerStructureRadius 1.3545
 HistoricTriggeroffset 0


### PR DESCRIPTION
Modified version of DigitBuilder that loads detectors with the new geometry class structure.  Also fixed a typo in the LoadWCSim tool and manually initialize the channel map after all detectors are loaded into the geometry.